### PR TITLE
Upgrade Trifid to 5.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@zazuko/trifid-markdown-content": "^2.0.2",
-        "@zazuko/trifid-plugin-ckan": "^4.0.0",
-        "trifid": "^5.0.2"
+        "@zazuko/trifid-plugin-ckan": "^4.0.1",
+        "trifid": "^5.0.3"
       }
     },
     "node_modules/@babel/parser": {
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-      "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-7.0.1.tgz",
-      "integrity": "sha512-i1p/nELMknAisNfnjo7yhfoUOdKzA+n92QaMirv2NkZrJ1Wl12v2nyTYlDwPN8XoStMBAnRK/Kx6zKmfrXUPXw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-7.0.3.tgz",
+      "integrity": "sha512-2tmTdF+uFCykasutaO6k4/wOt7eXyi7m3dGuCPo5micXzv0qt6ttb/nWnDYL/BlXjYGfp1JI4a1gyluTIylvQA==",
       "dependencies": {
         "@fastify/accept-negotiator": "^1.0.0",
         "@fastify/send": "^2.0.0",
@@ -169,14 +169,14 @@
       }
     },
     "node_modules/@fontsource/playfair-display": {
-      "version": "5.0.23",
-      "resolved": "https://registry.npmjs.org/@fontsource/playfair-display/-/playfair-display-5.0.23.tgz",
-      "integrity": "sha512-rR0Z2MBh0Ei8W272R/ESAW24fEKA9PBhdKZuH1FvvIBlpk25InFdri9TNX3lQ6Gyg8QV3QQvhcBrVZQlsAZvyQ=="
+      "version": "5.0.24",
+      "resolved": "https://registry.npmjs.org/@fontsource/playfair-display/-/playfair-display-5.0.24.tgz",
+      "integrity": "sha512-r+h+PWl8R4dIQ5FikbwUGBF/DPsozH7YcfCxEcUm9SthLCcdKT53KH7iNGhF8RTCV325dyu/JjrA3G3JPUl5hQ=="
     },
     "node_modules/@fontsource/roboto": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.12.tgz",
-      "integrity": "sha512-x0o17jvgoSSbS9OZnUX2+xJmVRvVCfeaYJjkS7w62iN7CuJWtMf5vJj8LqgC7ibqIkitOHVW+XssRjgrcHn62g=="
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.13.tgz",
+      "integrity": "sha512-j61DHjsdUCKMXSdNLTOxcG701FWnF0jcqNNQi2iPCDxU8seN/sMxeh62dC++UiagCWq9ghTypX+Pcy7kX+QOeQ=="
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "0.2.36",
@@ -415,9 +415,9 @@
       "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
     },
     "node_modules/@lit-labs/ssr/node_modules/@types/node": {
-      "version": "16.18.91",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.91.tgz",
-      "integrity": "sha512-h8Q4klc8xzc9kJKr7UYNtJde5TU2qEePVyH3WyzJaUC+3ptyc5kPQbWOIUcn8ZsG5+KSkq+P0py0kC0VqxgAXw=="
+      "version": "16.18.96",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.96.tgz",
+      "integrity": "sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ=="
     },
     "node_modules/@lit-labs/ssr/node_modules/node-fetch": {
       "version": "3.3.2",
@@ -982,9 +982,9 @@
       }
     },
     "node_modules/@tpluscode/rdf-string": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-1.2.0.tgz",
-      "integrity": "sha512-BbENGpxxIWlpb42rTCHJnlyAqQLcMKwtjeXVE28EMn702e0ULiM6gkkO1Ogz97A/+YRBr4aoe3klx9bSHHm1gA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-1.3.0.tgz",
+      "integrity": "sha512-VPIIg/+zivB1zJKzQ1yAC7HrrPF24WUJJMA/YNVlIOmA2vxAH7kXdSHGSNEDnDJ/UECMXkYLtKKSvc2ynFfEMw==",
       "dependencies": {
         "@rdfjs/data-model": "^2.0.0",
         "@rdfjs/environment": "^1.0.0",
@@ -1086,9 +1086,9 @@
       }
     },
     "node_modules/@types/rdfjs__data-model": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.7.tgz",
-      "integrity": "sha512-ysEnLulluo12hQLPulSheQIFrU3J+cV0X46NGUFO+TVsMDO4oc25KdrGD+9UnVAlUZTKJO6YYKWbDCl7V/0ADA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.8.tgz",
+      "integrity": "sha512-7OVjhmA8QPEdRReHFieKuqn2mbYx3ndEIEmh/6FkeJC8QCMJGVeSuRKEUVXbZGwP0rDKZuhQGozaRv3O1z1gPQ==",
       "peer": true,
       "dependencies": {
         "@rdfjs/types": "^1.0.1"
@@ -1248,11 +1248,12 @@
       }
     },
     "node_modules/@types/sparql-http-client": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/@types/sparql-http-client/-/sparql-http-client-2.2.15.tgz",
-      "integrity": "sha512-RAHFrVYYbZ/nqlf+X1rfJJOhUeJyOHU0hSz5JEG/U0iaPNNJWdU3fGuf5c7+Gq1AatibI9Exv/J/42unD5agHg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sparql-http-client/-/sparql-http-client-3.0.2.tgz",
+      "integrity": "sha512-sGQ7y+W/fhSM78vBjCuwaZPiM/UAfl5ZRmc6NoxddkqBmb5JEfUmTqts7lESzuG9XxDmLfiIXsrZjeSyDlPMlg==",
       "dependencies": {
-        "@rdfjs/types": ">=1.0.0"
+        "@rdfjs/types": ">=1.0.0",
+        "@types/rdfjs__environment": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -1371,9 +1372,9 @@
       "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g=="
     },
     "node_modules/@zazuko/env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-2.1.0.tgz",
-      "integrity": "sha512-/0CYISlrDSbdoYFBKgczQMyF8aTioEt07LMNpmsfMbOSvAMXpCDkss4Q/9i3sX4YaV8DertQFS68HxW+aBazvQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-2.1.1.tgz",
+      "integrity": "sha512-VgBErKSlzWosqTV5Z2n2aOh3EpvZaZWp3AUKqsZi9oYznU+Cv6PJwvO4S+F5TKzF9kvqczjiWE+UEWax4XUPfQ==",
       "dependencies": {
         "@rdfjs/data-model": "^2.0.1",
         "@rdfjs/dataset": "^2.0.1",
@@ -1383,7 +1384,7 @@
         "@rdfjs/term-set": "^2.0.1",
         "@rdfjs/traverser": "^0.1.2",
         "@tpluscode/rdf-ns-builders": "^4.1.0",
-        "@zazuko/env-core": "^1.0.0",
+        "@zazuko/env-core": "^1.1.2",
         "@zazuko/prefixes": "^2.1.0",
         "clownface": "^2.0.2",
         "get-stream": "^8.0.1",
@@ -1404,9 +1405,9 @@
       }
     },
     "node_modules/@zazuko/env-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@zazuko/env-core/-/env-core-1.1.1.tgz",
-      "integrity": "sha512-O/ScJLuQFlT0DdQzjakgbAXAKAbClp7AfxS1DQJfR7oABHJxi4NsLmmpF8wcBvyjwMZdpIWwWVF080ChLnwTNA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@zazuko/env-core/-/env-core-1.1.2.tgz",
+      "integrity": "sha512-mnLG40utuT7jPBPLs6fJ0puhfagnXSj+S8t9+zUGs3YlrOq/7b2zr64Hi3p3etwDdApaQ0VgQuNIY9doaruS1Q==",
       "dependencies": {
         "@rdfjs/environment": "^1.0.0"
       },
@@ -1686,29 +1687,25 @@
       }
     },
     "node_modules/@zazuko/trifid-entity-renderer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@zazuko/trifid-entity-renderer/-/trifid-entity-renderer-1.0.3.tgz",
-      "integrity": "sha512-hZdKQ0p9S+ZJY+ANDoePf6klnh5z2N5jI1l2WIvWAQfUsYx75K1DpV0BybxMWFJWgKyWcL4j1ak5AoaNj6inAA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@zazuko/trifid-entity-renderer/-/trifid-entity-renderer-1.0.4.tgz",
+      "integrity": "sha512-6WXC+3RDGmma5kvqm9MGN5ew5iAtNViy+peW8J5YsnMwJUJtlwlcQafbMbxKAYXI88JEKhvzh/K/OkbwMbY3lA==",
       "dependencies": {
         "@lit-labs/ssr": "^3.1.9",
         "@rdfjs/formats-common": "^3.1.0",
-        "@rdfjs/to-ntriples": "^2.0.0",
-        "@zazuko/env": "^2.0.6",
+        "@rdfjs/to-ntriples": "^3.0.1",
+        "@zazuko/env": "^2.1.1",
         "@zazuko/prefixes": "^2.1.0",
         "@zazuko/rdf-entity-webcomponent": "^0.7.7",
-        "lit": "^3.0.2",
+        "lit": "^3.1.3",
         "p-queue": "^8.0.1",
-        "trifid-core": "^4.0.2"
+        "trifid-core": "^4.0.5"
       }
     },
-    "node_modules/@zazuko/trifid-handle-redirects": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@zazuko/trifid-handle-redirects/-/trifid-handle-redirects-0.1.3.tgz",
-      "integrity": "sha512-K8zP2bTAcpBGlJlVxkPb5y5qXnIhmS47maI5vfxe0DrQDB47j3XVoWauJW7Ztgv421LB8d3WGdujWDaS7yg5CQ==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sparql-http-client": "^2.4.2"
-      }
+    "node_modules/@zazuko/trifid-entity-renderer/node_modules/@rdfjs/to-ntriples": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-3.0.1.tgz",
+      "integrity": "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ=="
     },
     "node_modules/@zazuko/trifid-markdown-content": {
       "version": "2.0.2",
@@ -1727,26 +1724,86 @@
       }
     },
     "node_modules/@zazuko/trifid-plugin-ckan": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@zazuko/trifid-plugin-ckan/-/trifid-plugin-ckan-4.0.0.tgz",
-      "integrity": "sha512-v3qdlDo4Ux/B5op1IcoQipn09xAap95Fn7Pkw7Ss19cT7Lx3SjS9e1Pn3UYfdzZ/wIR7j1eJdUm+DEbmtbeFew==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/trifid-plugin-ckan/-/trifid-plugin-ckan-4.0.1.tgz",
+      "integrity": "sha512-B0Io0TDhjBfj5YJn/hlFGvnSF9QMGNfE09ZgGIV1I82hK98CWSC1wIndWAYORKP1QSyIsZnmeGkYJA1g+m4xxA==",
       "dependencies": {
-        "@tpluscode/rdf-string": "^1.1.3",
-        "@zazuko/env": "^2.0.6",
+        "@tpluscode/rdf-string": "^1.3.0",
+        "@zazuko/env": "^2.1.1",
         "@zazuko/prefixes": "^2.1.1",
         "dotenv": "^16.3.1",
         "is-graph-pointer": "^2.1.0",
-        "sparql-http-client": "^2.4.2",
+        "sparql-http-client": "^3.0.0",
         "xmlbuilder2": "^3.1.1"
       }
     },
+    "node_modules/@zazuko/trifid-plugin-ckan/node_modules/@rdfjs/to-ntriples": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-3.0.1.tgz",
+      "integrity": "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ=="
+    },
+    "node_modules/@zazuko/trifid-plugin-ckan/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@zazuko/trifid-plugin-ckan/node_modules/nodeify-fetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-3.1.0.tgz",
+      "integrity": "sha512-ZV81vM//sEgTgXwVZlOONzcOCdTGQ53mV65FVSNXgPQHa8oCwRLtLbnGxL/1S/Yw90bcXUDKMz00jEnaeazo+A==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "node-fetch": "^3.2.10",
+        "readable-stream": "^4.2.0",
+        "stream-chunks": "^1.0.0"
+      }
+    },
+    "node_modules/@zazuko/trifid-plugin-ckan/node_modules/rdf-transform-triple-to-quad": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-transform-triple-to-quad/-/rdf-transform-triple-to-quad-2.0.0.tgz",
+      "integrity": "sha512-7PsiM9akR5cqV73r4JP5sXiie6I0uXvNtdf4PkAPuegywdymg2gjzrLJ4gb9TQjLhsHwHOHZDFQGX4bE9Ji1oQ==",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1",
+        "readable-stream": "3 - 4"
+      }
+    },
+    "node_modules/@zazuko/trifid-plugin-ckan/node_modules/sparql-http-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sparql-http-client/-/sparql-http-client-3.0.0.tgz",
+      "integrity": "sha512-apnk5baRm8VzQVWEyl1bxtOMDdf3un5XEnHv/yn8HfRFkyDBPT7KtPI0OW6OzJXBhMce6q9M76fjvm1uxJxiDQ==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.1",
+        "@rdfjs/data-model": "^2.0.2",
+        "@rdfjs/dataset": "^2.0.2",
+        "@rdfjs/environment": "^1.0.0",
+        "@rdfjs/parser-n3": "^2.0.2",
+        "@rdfjs/to-ntriples": "^3.0.1",
+        "duplex-to": "^2.0.0",
+        "nodeify-fetch": "^3.1.0",
+        "rdf-transform-triple-to-quad": "^2.0.0",
+        "readable-stream": "^4.5.2",
+        "stream-chunks": "^1.0.0"
+      }
+    },
     "node_modules/@zazuko/trifid-plugin-sparql-proxy": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@zazuko/trifid-plugin-sparql-proxy/-/trifid-plugin-sparql-proxy-2.0.1.tgz",
-      "integrity": "sha512-vsyGkKTWHFNd01rl36M3Wj1XZ0e6aq1P38nHIqNeKoL6yW3xqPsFZUj5ZoIUVtGKNVHXhl7/UUDyaazTcPM9FQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/trifid-plugin-sparql-proxy/-/trifid-plugin-sparql-proxy-2.1.0.tgz",
+      "integrity": "sha512-Xex3Ff2aDMxmt9iVTwBINc7ucAx7KAnZKA06hYGri853oZUzJe2BMKflP3ClV/jy8K+tyL5DaK2L/kK5A2WhcQ==",
       "dependencies": {
         "string-replace-stream": "^0.0.2",
-        "trifid-core": "^4.0.0"
+        "trifid-core": "^4.0.5"
       }
     },
     "node_modules/@zazuko/vue-graph-layout": {
@@ -1762,15 +1819,15 @@
       }
     },
     "node_modules/@zazuko/yasgui": {
-      "version": "4.2.34",
-      "resolved": "https://registry.npmjs.org/@zazuko/yasgui/-/yasgui-4.2.34.tgz",
-      "integrity": "sha512-MdbsdMtCQe9JzpDKAsmnAqCYIBg6ptV1TnqEtcWsBr8hrWWhP9RnE1ubxSZ2doQC+yvht8kCnsfqgLODHsDBnQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@zazuko/yasgui/-/yasgui-4.3.2.tgz",
+      "integrity": "sha512-P5rQtl4seNUMWrWUQkgmsPFtQcNWApCqNOm68miCjz2uBc0CA2BJrK3GXf/efBngf8L3IN0DPKLvfwJfFQwbCA==",
       "dependencies": {
         "@tarekraafat/autocomplete.js": "^7.2.0",
         "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.2.34",
-        "@zazuko/yasqe": "^4.2.34",
-        "@zazuko/yasr": "^4.2.34",
+        "@zazuko/yasgui-utils": "^4.3.2",
+        "@zazuko/yasqe": "^4.3.2",
+        "@zazuko/yasr": "^4.3.2",
         "autosuggest-highlight": "^3.1.1",
         "blueimp-md5": "^2.12.0",
         "choices.js": "^9.0.1",
@@ -1780,15 +1837,12 @@
         "lodash-es": "^4.17.15",
         "sortablejs": "^1.10.2",
         "superagent": "^8.1.2"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@zazuko/yasgui-utils": {
-      "version": "4.2.34",
-      "resolved": "https://registry.npmjs.org/@zazuko/yasgui-utils/-/yasgui-utils-4.2.34.tgz",
-      "integrity": "sha512-UJEPmx8DiEfqFvmCajDHWL6GcjaivIfPP26eqHIXx8brQ5zJnqImsNXfW3nMQCMKUO/3nENFP+d9I6/JK/b68w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@zazuko/yasgui-utils/-/yasgui-utils-4.3.2.tgz",
+      "integrity": "sha512-w1SzePqzj/hLVNlnMrrPCTEmysqaUeyMScbJnG7GB9rfSmhSlwh34lpEui1D6nxe7we956q8PHYXBlqzzn8NqQ==",
       "dependencies": {
         "@types/node": "^20.10.3",
         "dompurify": "^2.0.7",
@@ -1796,12 +1850,12 @@
       }
     },
     "node_modules/@zazuko/yasqe": {
-      "version": "4.2.34",
-      "resolved": "https://registry.npmjs.org/@zazuko/yasqe/-/yasqe-4.2.34.tgz",
-      "integrity": "sha512-yEtIfCJUY9DcvC/z3JMHwL2dlGKCQgDfbSvtZDRqtE4UU+Vr++qiQVOnoXD3cO62pi5zWpXxrg5IKHZb7bzFmg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@zazuko/yasqe/-/yasqe-4.3.2.tgz",
+      "integrity": "sha512-t5Qnk2tTeDA/vpcRYA6JHb5/WRhEsOmOuRzxyFZtJlRLGJUhG3fMJfH8GXMLIOCfEj4tUwVKPGSSFQSD3IpMZQ==",
       "dependencies": {
         "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.2.34",
+        "@zazuko/yasgui-utils": "^4.3.2",
         "codemirror": "^5.51.0",
         "lodash-es": "^4.17.15",
         "query-string": "^6.10.1",
@@ -1809,26 +1863,23 @@
       },
       "engines": {
         "node": ">= 8"
-      },
-      "peerDependencies": {
-        "@zazuko/yasgui": "4.x"
       }
     },
     "node_modules/@zazuko/yasr": {
-      "version": "4.2.34",
-      "resolved": "https://registry.npmjs.org/@zazuko/yasr/-/yasr-4.2.34.tgz",
-      "integrity": "sha512-b3U1u/Yuv2+6OZQWDefIO3zr8A48fkgepjN3HRwNZ9XFF6g8wJA8RYPi15Lpo09SGVgcEGrC5wUWkSTgqCNp0Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@zazuko/yasr/-/yasr-4.3.2.tgz",
+      "integrity": "sha512-D+H6CZMIFyJ8KBJVAp3z3F8D5EB+1/9K1T5+OKXlu3ps3gkW59RM+5lT4uzXYKID1LwHjolQC3+zISEJG/SIYQ==",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
         "@json2csv/plainjs": "^7.0.4",
         "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.2.34",
-        "@zazuko/yasqe": "^4.2.34",
+        "@zazuko/yasgui-utils": "^4.3.2",
+        "@zazuko/yasqe": "^4.3.2",
         "codemirror": "^5.51.0",
         "colors": "^1.4.0",
-        "column-resizer": "^1.3.4",
-        "datatables.net": "^1.10.24",
-        "datatables.net-dt": "^1.10.24",
+        "column-resizer": "^1.4.0",
+        "datatables.net": "^2.0.5",
+        "datatables.net-dt": "^2.0.5",
         "dompurify": "^2.0.7",
         "jquery": "^3.5.0",
         "lodash-es": "^4.17.15",
@@ -1837,9 +1888,6 @@
       },
       "engines": {
         "node": ">= 8"
-      },
-      "peerDependencies": {
-        "@zazuko/yasgui": "4.x"
       }
     },
     "node_modules/abort-controller": {
@@ -1871,14 +1919,14 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "uri-js": "^4.4.1"
       },
       "funding": {
         "type": "github",
@@ -2778,20 +2826,20 @@
       }
     },
     "node_modules/datatables.net": {
-      "version": "1.13.11",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.11.tgz",
-      "integrity": "sha512-AE6RkMXziRaqzPcu/pl3SJXeRa6fmXQG/fVjuRESujvkzqDCYEeKTTpPMuVJSGYJpPi32WGSphVNNY1G4nSN/g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.0.5.tgz",
+      "integrity": "sha512-Eu7z0ErFyr44hopfLQ7kyIWRdfqH2zFG93aHcnGKGrt/ICWXUsLrjUwghuN5b1pktnKzXCFYsl6Ad9WypiSNeA==",
       "dependencies": {
-        "jquery": "1.8 - 4"
+        "jquery": ">=1.7"
       }
     },
     "node_modules/datatables.net-dt": {
-      "version": "1.13.11",
-      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.11.tgz",
-      "integrity": "sha512-4GpS4OFLwIMfhb5UdJh6bEnh0E52jIJOlx7KLKs1pSce/xpHjvcmucbUWNaEndQIpHXtIxmVPoqcDB0ZbiVB+A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-2.0.5.tgz",
+      "integrity": "sha512-YVlBgz2rg5iWCp1wvtgknfgeoyuf+7YL5cR7avP0B10E6af+sIcCzcoMiP0g6wvnoyCVhlyah8alw2wNuRrBeA==",
       "dependencies": {
-        "datatables.net": "1.13.11",
-        "jquery": "1.8 - 4"
+        "datatables.net": "2.0.5",
+        "jquery": ">=1.7"
       }
     },
     "node_modules/dateformat": {
@@ -2928,9 +2976,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.9.tgz",
-      "integrity": "sha512-iHtnxYMotKgOTvxIqq677JsKHvCOkAFqj9x8Mek2zdeHW1XjuFKwjpmZeMaXQRQ8AbJZDbcRz/+r1QhwvFtmQg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.2.tgz",
+      "integrity": "sha512-5vSyvxRAb45EoWwAktUT3AYqAwXK4FL7si22Cgj46U6ICsj/YJczCN+Bk7WNABIQmpWRymGfslMhrRUZkQNnqA=="
     },
     "node_modules/dotenv": {
       "version": "16.4.5",
@@ -3098,17 +3146,33 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stringify": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.13.0.tgz",
-      "integrity": "sha512-XjTDWKHP3GoMQUOfnjYUbqeHeEt+PvYgvBdG2fRSmYaORILbSr8xTJvZX+w1YSAP5pw2NwKrGRmQleYueZEoxw==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.15.0.tgz",
+      "integrity": "sha512-BUEAAyDKb64u+kmkINYfXUUiKjBKerSmVu/dzotfaWSHBxR44JFrOZgkhMO6VxDhDfiuAoi8mx4drd5nvNdA4Q==",
       "dependencies": {
         "@fastify/merge-json-schemas": "^0.1.0",
         "ajv": "^8.10.0",
-        "ajv-formats": "^2.1.1",
+        "ajv-formats": "^3.0.1",
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^2.1.0",
         "json-schema-ref-resolver": "^1.0.1",
         "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/fast-printf": {
@@ -3252,13 +3316,13 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.1.0.tgz",
-      "integrity": "sha512-41QwjCGcVTODUmLLqTMeoHeiozbMXYMAE1CKFiDyi9zVZ2Vjh0yz3MF0WQZoIb+cmzP/XlbFjlF2NtJmvZHznA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
+      "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-querystring": "^1.0.0",
-        "safe-regex2": "^2.0.0"
+        "safe-regex2": "^3.1.0"
       },
       "engines": {
         "node": ">=14"
@@ -4138,9 +4202,9 @@
       }
     },
     "node_modules/light-my-request": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.12.0.tgz",
-      "integrity": "sha512-P526OX6E7aeCIfw/9UyJNsAISfcFETghysaWHQAlQYayynShT08MOj4c6fBCvTWBrHXSvqBAKDp3amUPSCQI4w==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.13.0.tgz",
+      "integrity": "sha512-9IjUN9ZyCS9pTG+KqTDEQo68Sui2lHsYBrfMyVUTTZ3XhH8PMZq7xO94Kr+eP9dhi/kcKsx4N41p2IXEBil1pQ==",
       "dependencies": {
         "cookie": "^0.6.0",
         "process-warning": "^3.0.0",
@@ -4148,9 +4212,9 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
-      "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.3.tgz",
+      "integrity": "sha512-l4slfspEsnCcHVRTvaP7YnkTZEZggNFywLEIhQaGhYDczG+tu/vlgm/KaWIEjIp+ZyV20r2JnZctMb8LeLCG7Q==",
       "dependencies": {
         "@lit/reactive-element": "^2.0.4",
         "lit-element": "^4.0.4",
@@ -4158,9 +4222,9 @@
       }
     },
     "node_modules/lit-element": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
-      "integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.5.tgz",
+      "integrity": "sha512-iTWskWZEtn9SyEf4aBG6rKT8GABZMrTWop1+jopsEOgEcugcXJGKuX5bEbkq9qfzY+XB4MAgCaSPwnNpdsNQ3Q==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0",
         "@lit/reactive-element": "^2.0.4",
@@ -4168,9 +4232,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
-      "integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.3.tgz",
+      "integrity": "sha512-FwIbqDD8O/8lM4vUZ4KvQZjPPNx7V1VhT7vmRB8RBAO0AU6wuTVdoXiu2CivVjEGdugvcbPNBLtPE1y0ifplHA==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -5435,39 +5499,39 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/pino": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.19.0.tgz",
-      "integrity": "sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "v1.1.0",
+        "pino-abstract-transport": "^1.2.0",
         "pino-std-serializers": "^6.0.0",
         "process-warning": "^3.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
         "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.0.0"
+        "thread-stream": "^2.6.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
-      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
       }
     },
     "node_modules/pino-pretty": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
-      "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.0.0.tgz",
+      "integrity": "sha512-YFJZqw59mHIY72wBnBs7XhLGG6qpJMa4pEQTRgEPEbjIYbng2LXEZZF1DoyDg9CfejEy8uZCyzpcBXXG0oOCwQ==",
       "dependencies": {
         "colorette": "^2.0.7",
         "dateformat": "^4.6.3",
@@ -5609,9 +5673,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -6068,11 +6132,11 @@
       }
     },
     "node_modules/ret": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.4.3.tgz",
+      "integrity": "sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==",
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
       }
     },
     "node_modules/reusify": {
@@ -6110,11 +6174,11 @@
       "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w=="
     },
     "node_modules/safe-regex2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
-      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
+      "integrity": "sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==",
       "dependencies": {
-        "ret": "~0.2.0"
+        "ret": "~0.4.0"
       }
     },
     "node_modules/safe-stable-stringify": {
@@ -6259,9 +6323,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
-      "integrity": "sha512-ybz6OYOUjoQQCQ/i4LU8kaToD8ACtYP+Cj5qd2AO36bwbdewxWJ3ArmJ2cr6AvxlL2o0PqnCcPGUgkILbfkaCA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -6672,6 +6736,7 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
       "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.4",
@@ -6708,9 +6773,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
-      "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -6767,39 +6832,38 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trifid": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/trifid/-/trifid-5.0.2.tgz",
-      "integrity": "sha512-0gTb1d7w3P0O3fZcOfkLJjQRRd4K1W6IgYmOfNh+HYS2onIw/ueTUtDlRZ/7aPOhf4dNwBidlmPIunJZMX35/A==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/trifid/-/trifid-5.0.3.tgz",
+      "integrity": "sha512-1+jgFWniZRb8x3yBxoLRJ03xaRwAdM0WVpb62GxyZWnj1oxqhzta30wjHF+FVOqxJzQpKUBAogzeVHH9muS3zQ==",
       "dependencies": {
-        "@zazuko/trifid-entity-renderer": "^1.0.3",
-        "@zazuko/trifid-handle-redirects": "^0.1.3",
-        "@zazuko/trifid-plugin-sparql-proxy": "^2.0.1",
+        "@zazuko/trifid-entity-renderer": "^1.0.4",
+        "@zazuko/trifid-plugin-sparql-proxy": "^2.1.0",
         "commander": "^12.0.0",
-        "trifid-core": "^4.0.0",
+        "trifid-core": "^4.0.5",
         "trifid-handler-fetch": "^3.0.0",
         "trifid-plugin-graph-explorer": "^2.0.2",
         "trifid-plugin-i18n": "^3.0.0",
         "trifid-plugin-spex": "^2.0.2",
-        "trifid-plugin-yasgui": "^3.0.2"
+        "trifid-plugin-yasgui": "^3.1.0"
       },
       "bin": {
         "trifid": "server.js"
       }
     },
     "node_modules/trifid-core": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/trifid-core/-/trifid-core-4.0.4.tgz",
-      "integrity": "sha512-vt/SplH/HpRRe/eRAJ6lbXZFviPFKfa0GuQNMQnhQpX1CRQM0yycKPysrRY3dBoVHZNSBtwdbA1MXbqGkWTgFg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/trifid-core/-/trifid-core-4.0.5.tgz",
+      "integrity": "sha512-i0nhDTPAA3QY/bVyrH8kULJNQvTGCNzMulBMwpG1uZngEoTQaD8sOXXcP2jNfJtJ5tI6mYDXMzlkK9ZAHjNKig==",
       "dependencies": {
         "@fastify/accepts": "^4.3.0",
         "@fastify/cookie": "^9.3.1",
         "@fastify/cors": "^9.0.1",
         "@fastify/formbody": "^7.4.0",
-        "@fastify/static": "^7.0.1",
-        "@fontsource/playfair-display": "^5.0.21",
-        "@fontsource/roboto": "^5.0.12",
+        "@fastify/static": "^7.0.3",
+        "@fontsource/playfair-display": "^5.0.24",
+        "@fontsource/roboto": "^5.0.13",
         "@rdfjs-elements/formats-pretty": "^0.6.7",
-        "@types/sparql-http-client": "^2.2.15",
+        "@types/sparql-http-client": "^3.0.2",
         "ajv": "^8.12.0",
         "commander": "^12.0.0",
         "fastify": "^4.26.1",
@@ -6807,14 +6871,74 @@
         "import-meta-resolve": "^4.0.0",
         "json5": "^2.2.3",
         "lodash": "^4.17.21",
-        "pino": "^8.17.1",
-        "pino-pretty": "^10.3.1",
-        "sparql-http-client": "^2.4.2",
+        "pino": "^8.20.0",
+        "pino-pretty": "^11.0.0",
+        "sparql-http-client": "^3.0.0",
         "string-replace-stream": "^0.0.2",
         "yaml": "^2.4.1"
       },
       "bin": {
         "trifid-core": "server.js"
+      }
+    },
+    "node_modules/trifid-core/node_modules/@rdfjs/to-ntriples": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-3.0.1.tgz",
+      "integrity": "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ=="
+    },
+    "node_modules/trifid-core/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/trifid-core/node_modules/nodeify-fetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-3.1.0.tgz",
+      "integrity": "sha512-ZV81vM//sEgTgXwVZlOONzcOCdTGQ53mV65FVSNXgPQHa8oCwRLtLbnGxL/1S/Yw90bcXUDKMz00jEnaeazo+A==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "node-fetch": "^3.2.10",
+        "readable-stream": "^4.2.0",
+        "stream-chunks": "^1.0.0"
+      }
+    },
+    "node_modules/trifid-core/node_modules/rdf-transform-triple-to-quad": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-transform-triple-to-quad/-/rdf-transform-triple-to-quad-2.0.0.tgz",
+      "integrity": "sha512-7PsiM9akR5cqV73r4JP5sXiie6I0uXvNtdf4PkAPuegywdymg2gjzrLJ4gb9TQjLhsHwHOHZDFQGX4bE9Ji1oQ==",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1",
+        "readable-stream": "3 - 4"
+      }
+    },
+    "node_modules/trifid-core/node_modules/sparql-http-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sparql-http-client/-/sparql-http-client-3.0.0.tgz",
+      "integrity": "sha512-apnk5baRm8VzQVWEyl1bxtOMDdf3un5XEnHv/yn8HfRFkyDBPT7KtPI0OW6OzJXBhMce6q9M76fjvm1uxJxiDQ==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.1",
+        "@rdfjs/data-model": "^2.0.2",
+        "@rdfjs/dataset": "^2.0.2",
+        "@rdfjs/environment": "^1.0.0",
+        "@rdfjs/parser-n3": "^2.0.2",
+        "@rdfjs/to-ntriples": "^3.0.1",
+        "duplex-to": "^2.0.0",
+        "nodeify-fetch": "^3.1.0",
+        "rdf-transform-triple-to-quad": "^2.0.0",
+        "readable-stream": "^4.5.2",
+        "stream-chunks": "^1.0.0"
       }
     },
     "node_modules/trifid-handler-fetch": {
@@ -6855,13 +6979,13 @@
       }
     },
     "node_modules/trifid-plugin-yasgui": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/trifid-plugin-yasgui/-/trifid-plugin-yasgui-3.0.3.tgz",
-      "integrity": "sha512-KiyGIKXST1jE0J5VMmXqu5sxY5Ao5UGJaZcPyF4xhjkVvmswyVyFQqU2G+XWQPqQHAj88DqGnkdKKHBL+zXfYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/trifid-plugin-yasgui/-/trifid-plugin-yasgui-3.1.0.tgz",
+      "integrity": "sha512-/m5SdOIuW9AWcv1ucr+qe8Lh4hpj+IRmQ1SdZKaKrv8SOqi20tSSWGZbDy8vivlZG9ge06OP5fWiprgPlGKFAg==",
       "dependencies": {
-        "@fastify/static": "^7.0.1",
+        "@fastify/static": "^7.0.3",
         "@openlayers-elements/bundle": "^0.1.0",
-        "@zazuko/yasgui": "^4.2.34",
+        "@zazuko/yasgui": "^4.3.2",
         "import-meta-resolve": "^4.0.0"
       }
     },
@@ -7331,9 +7455,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
-      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
+      "integrity": "sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "dependencies": {
     "@zazuko/trifid-markdown-content": "^2.0.2",
-    "@zazuko/trifid-plugin-ckan": "^4.0.0",
-    "trifid": "^5.0.2"
+    "@zazuko/trifid-plugin-ckan": "^4.0.1",
+    "trifid": "^5.0.3"
   },
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
This upgrades the following packages:
- `trifid`: 5.0.2 → 5.0.3
- `@zazuko/trifid-plugin-ckan`: 4.0.0 → 4.0.1